### PR TITLE
Fix non-working size, flip, rotate, viewbox attributes

### DIFF
--- a/lib/svg-icon.js
+++ b/lib/svg-icon.js
@@ -26,8 +26,16 @@ class SvgIcon extends HTMLElement {
 		return this.getAttribute('size') || this.defaults.size
 	}
 
+	set size(value) {
+		this.setAttribute('size', value)
+	}
+
 	get viewbox() {
 		return this.getAttribute('viewbox') || this.defaults.viewbox
+	}
+
+	set viewbox(value) {
+		this.setAttribute('viewbox', value)
 	}
 
 	get flip() {
@@ -38,11 +46,19 @@ class SvgIcon extends HTMLElement {
 		}
 	}
 
-	get rotate() {
-		const rotate = this.getAttribute('rotate')
+	set flip(value) {
+		this.setAttribute('flip', value)
+	}
 
-		if (!isNaN(rotate)) return rotate + 'deg'
+	get rotate() {
+		const rotate = this.getAttribute('rotate') || 0
+		if (!isNaN(rotate))
+			return rotate + 'deg'
 		return rotate
+	}
+
+	set rotate(value) {
+		this.setAttribute('rotate', value)
 	}
 
 	constructor(...args) {


### PR DESCRIPTION
Hello there!

While trying to use the size attribute of the component I ran into an issue (both on Firefox 113.0.1 and Edge 113.0.1774.50) where all attributes except type and path wouldn't work.

After investigation, it seems having attributes and properties with the same name means both the setter and getter must be implemented otherwise setting the attribute value is ignored (at least from the dom, which is the most common case I guess).

In this PR I added setters for all properties that had getter. The only thing setters are doing is setting the actual attribute on the element.

It could be worth considering renaming the properties that do some stuff (defaulting to types values or parsing) and are not just get the current value of the attribute which could be confusing.

Thanks and have a nice day!