### PR TITLE
[hotfix] Fix `setPath` trying to mutate the wrong target

### DIFF
--- a/lib/svg-icon.js
+++ b/lib/svg-icon.js
@@ -98,7 +98,7 @@ class SvgIcon extends HTMLElement {
 	setPath() {
 		const path = this.getAttribute('path')
 
-		this.path.setAttribute('d', path)
+		this.svg.setAttribute('d', path)
 	}
 
 	setWidth() {


### PR DESCRIPTION
The current version of the lib is not working anymore, due to a line trying to mutate `this.path` (which is a user-defined string) instead of `this.svg` (the target svg element).

Currently, any use of the lib crashes with this error, hence the "hotfix" label.
<img width="589" alt="image" src="https://github.com/user-attachments/assets/958edd7f-4757-4c30-af14-5ea248fc98c6" />
